### PR TITLE
Add support for setting UTM params via API

### DIFF
--- a/snippets/link-arguments.mdx
+++ b/snippets/link-arguments.mdx
@@ -86,3 +86,28 @@
 <ParamField body="android" type="string | null">
   The Android destination URL for the short link for Android device targeting.
 </ParamField>
+
+<ParamField body="utm_source" type="string | null">
+  The UTM source of the short link. If set, this will populate or override the
+  UTM source in the destination URL.
+</ParamField>
+
+<ParamField body="utm_medium" type="string | null">
+  The UTM medium of the short link. If set, this will populate or override the
+  UTM medium in the destination URL.
+</ParamField>
+
+<ParamField body="utm_campaign" type="string | null">
+  The UTM campaign of the short link. If set, this will populate or override the
+  UTM campaign in the destination URL.
+</ParamField>
+
+<ParamField body="utm_term" type="string | null">
+  The UTM term of the short link. If set, this will populate or override the UTM
+  term in the destination URL.
+</ParamField>
+
+<ParamField body="utm_content" type="string | null">
+  The UTM content of the short link. If set, this will populate or override the
+  UTM content in the destination URL.
+</ParamField>


### PR DESCRIPTION
- `utm_source`: The UTM source of the short link.
- `utm_medium`: The UTM medium of the short link.
- `utm_campaign`: The UTM campaign of the short link.
- `utm_term`: The UTM term of the short link.
- `utm_content`: The UTM content of the short link.