### PR TITLE
Fix: Remove `apps/docs` reference in the local development guide

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -347,4 +347,4 @@ Finally, you can start the development server. This will build the packages + st
 pnpm dev
 ```
 
-The web app (`apps/web`) will be available at [localhost:8888](http://localhost:8888) and the docs (`apps/docs`) will be available at [localhost:3334](http://localhost:3334).
+The web app (`apps/web`) will be available at [localhost:8888](http://localhost:8888).


### PR DESCRIPTION
Minor fix as the `docs` has been removed from monorepo structure