### PR TITLE
[🕹️ oss.gg hackathon] Updated Hyper Links to the Respective GitHub Repo

### DIFF
--- a/quickstart/nextjs.mdx
+++ b/quickstart/nextjs.mdx
@@ -147,7 +147,7 @@ const timeseries = response as ClicksTimeseries[];
   <Card
     title="Next.js Example"
     icon="github"
-    href="https://github.com/dubinc/examples"
+    href="https://github.com/dubinc/examples/tree/main/typescript/next"
     color="#333333"
   >
     See the full example on GitHub.

--- a/quickstart/typescript.mdx
+++ b/quickstart/typescript.mdx
@@ -113,7 +113,7 @@ const timeseries = response as ClicksTimeseries[];
   <Card
     title="TypeScript Example"
     icon="github"
-    href="https://github.com/dubinc/examples/tree/main/node"
+    href="https://github.com/dubinc/examples/tree/main/typescript"
     color="#333333"
   >
     See the full example on GitHub.


### PR DESCRIPTION
### Changes Made

Updated the hyperlinks to the respective GitHub example repos.

1. The first gave a 404, updated it to show all the Typescript examples.
2. The next.js link showed all the typescript examples, changed the link to the respective next.js example link.