### PR TITLE
fix(local-dev): add packages build step

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -100,6 +100,16 @@ First, clone the [Dub.co repo](https://d.to/github) into a public GitHub reposit
 
   </Step>
 
+  <Step title="Build internal packages">
+
+    Execute the command below to compile all internal packages:
+
+    ```bash Terminal
+    pnpm -r --filter "./packages/**" build
+    ```
+
+  </Step>
+
   <Step title="Set up environment variables">
 
     Copy the `.env.example` file to `.env`:


### PR DESCRIPTION
### What does this PR do?

Adds a missing step to Dub's local setup guide suggesting the compilation of the internal packages used by the web application.