### PR TITLE
Update environment variable configuration steps for NextAuth

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Local Development"
-"og:title": "How to setup Dub.co for Local Development (6 steps)"
+"og:title": "How to setup Dub.co for Local Development (7 steps)"
 description: "A guide on how to run Dub.co's codebase locally."
 icon: code
 ---
@@ -393,7 +393,33 @@ To view emails sent from your application during local development, you'll need 
 
 </Steps>
 
-## Step 6: Start the development server
+## Step 6: Set up NextAuth
+
+<Steps>
+
+  <Step title="Generate a random secret">
+
+    Run the following command to generate a random secret
+
+    ```bash Terminal
+    openssl rand -base64 32
+    ```
+
+  </Step>
+
+  <Step title="Set up environment variable">
+
+    Add the generated secret to `.env` file
+
+    ```
+    NEXTAUTH_SECRET=<secret>
+    ```
+
+  </Step>
+
+</Steps>
+
+## Step 7: Start the development server
 
 Finally, you can start the development server. This will build the packages + start the app servers.
 


### PR DESCRIPTION
# Editing local development guide section
Fixes #111 

Internally the repo also depends upon a dependency "NextAuth" for auth, however it was not discussed in docs, so I thought maybe we can give it as a separate step.

<img width="768" alt="Step 6 Set up NextAuth" src="https://github.com/user-attachments/assets/99a90f87-e633-449d-aae1-53ccd3b8ce67">

I have added steps in the documentation accordingly
