### PR TITLE
Fix: Correct .env.example File Path for Local Environment Setup

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -112,10 +112,10 @@ First, clone the [Dub.co repo](https://d.to/github) into a public GitHub reposit
 
   <Step title="Set up environment variables">
 
-    Copy the `.env.example` file to `.env`:
+    Copy the `.env.example` file from ./apps/web to `.env`:
 
     ```bash Terminal
-    cp .env.example .env
+    cp ./apps/web/.env.example .env
     ```
 
     You'll be updating this `.env` file with your own values as you progress through the setup.

--- a/local-development.mdx
+++ b/local-development.mdx
@@ -112,7 +112,7 @@ First, clone the [Dub.co repo](https://d.to/github) into a public GitHub reposit
 
   <Step title="Set up environment variables">
 
-    Copy the `.env.example` file from ./apps/web to `.env`:
+    Copy the `.env.example` file from `./apps/web` to `.env`:
 
     ```bash Terminal
     cp ./apps/web/.env.example .env


### PR DESCRIPTION
This command cannot be executed from the project root because `.env.example` does not exist there. Therefore, I updated the path to `./apps/web/.env.example`

# Before

![Screenshot from 2024-12-31 00-51-14](https://github.com/user-attachments/assets/6e4311d3-167d-4d25-aece-d6d73109afb6)

# After

![Screenshot from 2024-12-31 00-57-33](https://github.com/user-attachments/assets/e48d873f-6306-419e-9427-ad5013c8a778)

