### PR TITLE
Add Appwrite to auth providers for leads tracking

### DIFF
--- a/conversions/leads/appwrite.mdx
+++ b/conversions/leads/appwrite.mdx
@@ -1,0 +1,224 @@
+---
+title: "Appwrite"
+"og:title": "Appwrite Lead Tracking – Dub Conversions"
+description: "Learn how to track lead conversion events with Appwrite and Dub"
+---
+
+import LeadsIntro from "/snippets/leads-intro.mdx";
+import LeadsPrerequisites from "/snippets/leads-prerequisites.mdx";
+import LeadsAttributes from "/snippets/leads-attributes.mdx";
+import LeadsOutro from "/snippets/leads-outro.mdx";
+
+<LeadsIntro />
+
+In this guide, we will be focusing on tracking new user sign-ups for a SaaS application that uses Appwrite for user authentication.
+
+<LeadsPrerequisites />
+
+## Configure Appwrite
+
+
+Next, configure Appwrite to track lead conversion events during the sign up process.
+
+<Steps>
+
+  <Step title="Create an Appwrite Cloud project">
+
+    Head to [Appwrite Cloud](https://apwr.dev/appwrite-dub) and create a new project. Create a new API key with the `sessions.write` scope enabled and save the API key for later use. You can also copy your project ID and endpoint from the project's Settings page.
+
+    Then, in your Next.js app, install the Appwrite Node.js SDK.
+    ```bash
+    npm i node-appwrite
+    ```
+  
+  </Step>
+
+  <Step title="Add environment variables">
+    
+    Add the following environment variables to your app.
+
+    ```bash
+    NEXT_PUBLIC_APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
+    NEXT_PUBLIC_APPWRITE_PROJECT=<APPWRITE_PROJECT_ID>
+    NEXT_APPWRITE_KEY=<APPWRITE_API_KEY>
+    NEXT_DUB_API_KEY=<DUB_API_KEY>
+    ```
+
+  </Step>
+
+  <Step title="Integrate Dub Analytics">
+
+    Add the `DubAnalytics` component from the `@dub/analytics` package to your app’s root layout.
+
+    ```tsx app/layout.tsx
+    import type { Metadata } from 'next';
+    import { Analytics as DubAnalytics } from '@dub/analytics/react';
+
+    export const metadata: Metadata = {
+      title: 'Appwrite Dub Leads Example',
+      description: 'Appwrite Dub Leads Tracking example app with Next.js'
+    };
+
+    export default function RootLayout({
+      children
+    }: Readonly<{
+      children: React.ReactNode;
+    }>) {
+      return (
+        <html lang="en">
+          <body>{children}</body>
+          <DubAnalytics />
+        </html>
+      );
+    }
+    ```
+
+  </Step>
+
+  <Step title="Prepare the Appwrite client and auth library">
+
+    Create the Appwrite Session and Admin client (necessary for SSR apps, as explained in the Appwrite docs). Additionally, create a function to verify user login.
+
+    ```ts lib/server/appwrite.ts
+    'use server';
+    import { Client, Account } from 'node-appwrite';
+    import { cookies } from 'next/headers';
+
+    export async function createSessionClient() {
+      const client = new Client()
+        .setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT as string)
+        .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT as string);
+
+      const session = (await cookies()).get('my-custom-session');
+      if (!session || !session.value) {
+        throw new Error('No session');
+      }
+
+      client.setSession(session.value);
+
+      return {
+        get account() {
+          return new Account(client);
+        }
+      };
+    }
+
+    export async function createAdminClient() {
+      const client = new Client()
+        .setEndpoint(process.env.NEXT_PUBLIC_APPWRITE_ENDPOINT as string)
+        .setProject(process.env.NEXT_PUBLIC_APPWRITE_PROJECT as string)
+        .setKey(process.env.NEXT_APPWRITE_KEY as string);
+
+      return {
+        get account() {
+          return new Account(client);
+        }
+      };
+    }
+    ```
+  </Step>
+
+  <Step title="Set up Dub SDK">
+
+    Create the Dub client and send leads to Dub using the `dub.track.lead()` function.
+
+    ```ts lib/server/dub.ts
+    import type { Models } from 'node-appwrite';
+    import { Dub } from 'dub';
+
+    const dub = new Dub({
+      token: process.env.NEXT_DUB_API_KEY
+    });
+
+    export function addDubLead(user: Models.User<Models.Preferences>, dub_id: string) {
+      dub.track.lead({
+        clickId: dub_id,
+        eventName: 'Sign Up',
+        externalId: user.$id,
+        customerName: user.name,
+        customerEmail: user.email
+      });
+    }
+    ```
+
+  </Step>
+
+  <Step title="Send leads to Dub on user signup">
+    In the `/auth` page, use the Appwrite Admin client to allow users to sign up. Post sign up, check if the `dub_id` cookie is present, send a lead event to Dub if found, and delete the `dub_id` cookie.
+
+    ```tsx app/auth/page.tsx
+    import { ID } from 'node-appwrite';
+    import { createAdminClient, getLoggedInUser } from '@/lib/server/appwrite';
+    import { cookies } from 'next/headers';
+    import { redirect } from 'next/navigation';
+    import { addDubLead } from '@/lib/server/dub';
+
+    async function signUpWithEmail(formData: any) {
+      'use server';
+
+      // Get sign up info from form
+      const email = formData.get('email');
+      const password = formData.get('password');
+      const name = formData.get('name');
+
+      // Create account and session using Appwrite
+      const { account } = await createAdminClient();
+
+      const user = await account.create(ID.unique(), email, password, name);
+      const session = await account.createEmailPasswordSession(email, password);
+
+      (await cookies()).set('my-custom-session', session.secret, {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'strict',
+        secure: true
+      });
+
+      // Check if Dub ID is present in cookies and track lead if found
+      const dub_id = (await cookies()).get('dub_id')?.value;
+      if (dub_id) {
+        addDubLead(user, dub_id);
+        (await cookies()).delete('dub_id');
+      }
+
+      // Redirect to success page
+      redirect('/auth/success');
+    }
+
+    export default async function SignUpPage() {
+
+      // Verify active user session and redirect to success page if found
+      const user = await getLoggedInUser();
+      if (user) redirect('/auth/success');
+
+      return (
+        <>
+          <form action={signUpWithEmail}>
+            <input id="email" name="email" placeholder="Email" type="email" required />
+            <input id="password" name="password" placeholder="Password" minLength={8} type="password" required />
+            <input id="name" name="name" placeholder="Name" type="text" required />
+            <button type="submit">Sign up</button>
+          </form>
+        </>
+      );
+    }
+    ```
+  </Step>
+
+</Steps>
+
+<LeadsAttributes />
+
+## Example App
+
+To learn more about how to track leads with Appwrite, check out the following example app:
+
+<Card
+  title="Appwrite + Dub Next.js  Example"
+  icon="github"
+  href="https://github.com/appwrite-community/appwrite-dub-next"
+>
+  See how to track new user sign-ups with Appwrite and the Dub SDK.
+</Card>
+
+<LeadsOutro />

--- a/mint.json
+++ b/mint.json
@@ -68,7 +68,8 @@
             "conversions/leads/clerk",
             "conversions/leads/next-auth",
             "conversions/leads/supabase",
-            "conversions/leads/auth0"
+            "conversions/leads/auth0",
+            "conversions/leads/appwrite"
           ]
         },
         {

--- a/snippets/auth-providers.mdx
+++ b/snippets/auth-providers.mdx
@@ -35,4 +35,13 @@
   >
     Tracking lead events with Auth0
   </Card>
+  <Card
+    title="Appwrite"
+    icon="shield-halved"
+    iconType="solid"
+    href="/conversions/leads/appwrite"
+    horizontal
+  >
+    Tracking lead events with Appwrite
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Description

Adds Appwrite as an Auth Provider for tracking leads (including a Next.js demo app)

## Files changes

- `conversions/leads/appwrite.mdx`: Appwrite configuration tutorial is created
- `snippets/auth-providers.mdx`: Appwrite is added to the list of providers
- `mint.json`: Appwrite is added to 'Leads' group for visibility in sidebar