### PR TITLE
Order and language change

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -282,11 +282,11 @@ Prerequisites:
 
   <Step title="Set up database environment variables">
 
-    Add the following credentials to your `.env` file:
+    Ensure the following credientials are added to your `.env` file:
 
     ```
-    PLANETSCALE_DATABASE_URL="http://root:unused@localhost:3900/planetscale"
     DATABASE_URL="mysql://root:@localhost:3306/planetscale"
+    PLANETSCALE_DATABASE_URL="http://root:unused@localhost:3900/planetscale"
     ```
 
     Here, we are using the open-source [PlanetScale simulator](https://github.com/mattrobenolt/ps-http-sim) so the application can continue to use the `@planetscale/database` SDK.


### PR DESCRIPTION
Updated the order of the planetscale credentials to match how it's provided in the example .env file.

Updated the language to make it a "double check" vs "you're missing these".