### PR TITLE
Update clerk trackLead server action with try/catch + error type on res

### DIFF
--- a/conversions/leads/clerk.mdx
+++ b/conversions/leads/clerk.mdx
@@ -144,7 +144,7 @@ Here's a quick summary of the steps:
     import { dub } from "@/lib/dub";
     import { clerkClient } from "@clerk/nextjs/server";
     import { cookies } from "next/headers";
-
+    
     export async function trackLead({
       id,
       name,
@@ -156,35 +156,40 @@ Here's a quick summary of the steps:
       email?: string | null;
       avatar?: string | null;
     }) {
-      const cookieStore = await cookies();
-      const dubId = cookieStore.get("dub_id")?.value;
-      if (dubId) {
-        // Send lead event to Dub
-        await dub.track.lead({
-          clickId: dubId,
-          eventName: "Sign Up",
-          externalId: id,
-          customerName: name,
-          customerEmail: email,
-          customerAvatar: avatar,
+      try {
+        const cookieStore = await cookies();
+        const dubId = cookieStore.get("dub_id")?.value;
+    
+        if (dubId) {
+          // Send lead event to Dub
+          await dub.track.lead({
+            clickId: dubId,
+            eventName: "Sign Up",
+            externalId: id,
+            customerName: name,
+            customerEmail: email,
+            customerAvatar: avatar,
+          });
+    
+          // Delete the dub_id cookie
+          cookieStore.set("dub_id", "", {
+            expires: new Date(0),
+          });
+        }
+    
+        const clerk = await clerkClient();
+        await clerk.users.updateUser(id, {
+          publicMetadata: {
+            dubClickId: dubId || "n/a",
+          },
         });
-
-        // Delete the dub_id cookie
-        cookieStore.set("dub_id", "", {
-          expires: new Date(0),
-        });
+    
+        return { ok: true };
+      } catch (error) {
+        console.error("Error in trackLead:", error);
+        return { ok: false, error: (error as Error).message };
       }
-
-      const clerk = await clerkClient();
-      await clerk.users.updateUser(id, {
-        publicMetadata: {
-          dubClickId: dubId || "n/a",
-        },
-      });
-
-      return { ok: true };
     }
-
     ```
 
     ```tsx /api/track-lead/route.ts


### PR DESCRIPTION
The `res` response didn't have the error prop returned in the object, which formerly made the client component in this example have a type mismatch. 

For example, in [step 3 within the docs](https://dub.co/docs/conversions/leads/clerk) the following `res.error` usage was missing the `error` prop without the changes herein:
```tsx
    // if the user is loaded but hasn't been persisted to Dub yet, track the lead event
    trackLead({
      id: user.id,
      name: user.fullName!,
      email: user.primaryEmailAddress?.emailAddress,
      avatar: user.imageUrl,
    }).then(async (res) => {
      if (res.ok) await user.reload();
      else console.error(res.error);
    });
```
> This is the code as is

This PR adds a try-catch block to the example and adds the error type to the return statement.

```tsx
try {
  ...
} catch (error) {
  console.error("Error in trackLead:", error);
  return { ok: false, error: (error as Error).message };
}
```
> This is a pseudo-implementation of the major change

I'm just slamming in what we have in our code base with these conversions that worked so please let me know if you'd like changes or see a different direction (or want to close this!). 