### PR TITLE
Partner's total stats to `commission.created` webhook

### DIFF
--- a/concepts/webhooks/event-types.mdx
+++ b/concepts/webhooks/event-types.mdx
@@ -489,6 +489,7 @@ Here's an example payload:
       "totalLeads": 15,
       "totalConversions": 10,
       "totalSales": 10,
+      "totalSaleAmount": 100000,
       "totalCommissions": 50000
     },
     "customer": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * commission.created webhook payload now includes aggregated partner metrics: totalClicks, totalLeads, totalConversions, totalSales, totalSaleAmount, and totalCommissions, enabling richer reporting and analytics.

* **Documentation**
  * Updated webhook event documentation and sample payload to reflect the new partner metrics in commission.created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->