### PR TITLE
Adds authentication docs

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -430,6 +430,13 @@ pnpm dev
 
 The web app (`apps/web`) will be available at [localhost:8888](http://localhost:8888). Additionally, you may access Prisma Studio to manage your MySQL database at [localhost:5555](http://localhost:5555).
 
+### Authenticating
+
+Email login is the preferred method of authentication for local development. You may create an account at `localhost:8888/register` which will require email verification. 
+
+You may obtain your verification code from the `EmailVerificationToken` table in Prisma Studio at `localhost:5555`.
+
+
 ### Testing your shortlinks locally
 
 Use the following url structure to ensure event tracking is working, and to populate analytics data, replacing `<shortlink-key>` with the shortlink key you've created.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Authenticating” section to local development docs, detailing email-based login, account creation at localhost:8888/register, and retrieving the verification code via Prisma Studio (EmailVerificationToken) at localhost:5555.
  * Clarified “Testing your shortlinks locally” with an explicit sample URL: http://dub.localhost:8888/<shortlink-key>.
  * Text and formatting updates only; no changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->