### PR TITLE
Reorganize third-party integrations

### DIFF
--- a/conversions/leads/appwrite.mdx
+++ b/conversions/leads/appwrite.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Appwrite"
+title: "Appwrite (auth)"
 "og:title": "How to track lead conversion events with Appwrite and Dub"
 description: "Learn how to track lead conversion events with Appwrite and Dub"
 ---

--- a/conversions/leads/appwrite.mdx
+++ b/conversions/leads/appwrite.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Appwrite (auth)"
+title: "Appwrite"
+sidebarTitle: "Appwrite (Auth)"
 "og:title": "How to track lead conversion events with Appwrite and Dub"
 description: "Learn how to track lead conversion events with Appwrite and Dub"
 ---

--- a/conversions/leads/auth0.mdx
+++ b/conversions/leads/auth0.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Auth0"
+title: "Auth0 (auth)"
 "og:title": "How to track lead conversion events with Auth0 and Dub"
 description: "Learn how to track lead conversion events with Auth0 and Dub"
 ---

--- a/conversions/leads/auth0.mdx
+++ b/conversions/leads/auth0.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Auth0 (auth)"
+title: "Auth0"
+sidebarTitle: "Auth0 (Auth)"
 "og:title": "How to track lead conversion events with Auth0 and Dub"
 description: "Learn how to track lead conversion events with Auth0 and Dub"
 ---

--- a/conversions/leads/better-auth.mdx
+++ b/conversions/leads/better-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Better Auth"
+title: "Better Auth (auth)"
 "og:title": "How to track lead conversion events with Better Auth and Dub"
 "og:image": "https://assets.dub.co/cms/better-dub.jpg"
 description: "Learn how to track lead conversion events with Better Auth and Dub"

--- a/conversions/leads/better-auth.mdx
+++ b/conversions/leads/better-auth.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Better Auth (auth)"
+title: "Better Auth"
+sidebarTitle: "Better Auth (Auth)"
 "og:title": "How to track lead conversion events with Better Auth and Dub"
 "og:image": "https://assets.dub.co/cms/better-dub.jpg"
 description: "Learn how to track lead conversion events with Better Auth and Dub"

--- a/conversions/leads/clerk.mdx
+++ b/conversions/leads/clerk.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Clerk (auth)"
+title: "Clerk"
+sidebarTitle: "Clerk (Auth)"
 "og:title": "How to track lead conversion events with Clerk and Dub"
 description: "Learn how to track lead conversion events with Clerk and Dub"
 ---

--- a/conversions/leads/clerk.mdx
+++ b/conversions/leads/clerk.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Clerk"
+title: "Clerk (auth)"
 "og:title": "How to track lead conversion events with Clerk and Dub"
 description: "Learn how to track lead conversion events with Clerk and Dub"
 ---

--- a/conversions/leads/next-auth.mdx
+++ b/conversions/leads/next-auth.mdx
@@ -1,5 +1,6 @@
 ---
-title: "NextAuth.js (auth)"
+title: "NextAuth.js"
+sidebarTitle: "NextAuth.js (Auth)"
 "og:title": "How to track lead conversion events with NextAuth.js and Dub"
 description: "Learn how to track lead conversion events with NextAuth.js and Dub"
 ---

--- a/conversions/leads/next-auth.mdx
+++ b/conversions/leads/next-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: "NextAuth.js"
+title: "NextAuth.js (auth)"
 "og:title": "How to track lead conversion events with NextAuth.js and Dub"
 description: "Learn how to track lead conversion events with NextAuth.js and Dub"
 ---

--- a/conversions/leads/segment.mdx
+++ b/conversions/leads/segment.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Segment (analytics)"
+title: "Segment"
+sidebarTitle: "Segment (Analytics)"
 "og:title": "How to track lead conversion events with Segment and Dub"
 description: "Learn how to track lead conversion events with Segment and Dub"
 ---

--- a/conversions/leads/segment.mdx
+++ b/conversions/leads/segment.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Segment"
+title: "Segment (analytics)"
 "og:title": "How to track lead conversion events with Segment and Dub"
 description: "Learn how to track lead conversion events with Segment and Dub"
 ---

--- a/conversions/leads/supabase.mdx
+++ b/conversions/leads/supabase.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Supabase (auth)"
+title: "Supabase"
+sidebarTitle: "Supabase (Auth)"
 "og:title": "How to track lead conversion events with Supabase and Dub"
 description: "Learn how to track lead conversion events with Supabase and Dub"
 ---

--- a/conversions/leads/supabase.mdx
+++ b/conversions/leads/supabase.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Supabase"
+title: "Supabase (auth)"
 "og:title": "How to track lead conversion events with Supabase and Dub"
 description: "Learn how to track lead conversion events with Supabase and Dub"
 ---

--- a/conversions/sales/segment.mdx
+++ b/conversions/sales/segment.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Segment (analytics)"
+title: "Segment"
+sidebarTitle: "Segment (Analytics)"
 "og:title": "How to track sale conversion events with Segment and Dub"
 description: "Learn how to track sale conversion events with Segment and Dub"
 ---

--- a/conversions/sales/segment.mdx
+++ b/conversions/sales/segment.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Segment"
+title: "Segment (analytics)"
 "og:title": "How to track sale conversion events with Segment and Dub"
 description: "Learn how to track sale conversion events with Segment and Dub"
 ---

--- a/conversions/sales/shopify.mdx
+++ b/conversions/sales/shopify.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Shopify"
+title: "Shopify (payments)"
 "og:title": "How to track sale conversion events with Shopify and Dub"
 description: "Learn how to track sale conversion events with Shopify and Dub"
 ---

--- a/conversions/sales/shopify.mdx
+++ b/conversions/sales/shopify.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Shopify (payments)"
+title: "Shopify"
+sidebarTitle: "Shopify (Payments)"
 "og:title": "How to track sale conversion events with Shopify and Dub"
 description: "Learn how to track sale conversion events with Shopify and Dub"
 ---

--- a/conversions/sales/stripe.mdx
+++ b/conversions/sales/stripe.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Stripe (payments)"
+title: "Stripe"
+sidebarTitle: "Stripe (Payments)"
 "og:title": "How to track sale conversion events with Stripe and Dub"
 description: "Learn how to track sale conversion events with Stripe and Dub"
 ---

--- a/conversions/sales/stripe.mdx
+++ b/conversions/sales/stripe.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Stripe"
+title: "Stripe (payments)"
 "og:title": "How to track sale conversion events with Stripe and Dub"
 description: "Learn how to track sale conversion events with Stripe and Dub"
 ---

--- a/docs.json
+++ b/docs.json
@@ -9,7 +9,14 @@
   },
   "favicon": "/logos/favicon.png",
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude", "cursor", "vscode"]
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "cursor",
+      "vscode"
+    ]
   },
   "navigation": {
     "anchors": [
@@ -18,7 +25,9 @@
         "groups": [
           {
             "group": "Getting Started",
-            "pages": ["introduction"]
+            "pages": [
+              "introduction"
+            ]
           },
           {
             "group": "Links",
@@ -63,8 +72,9 @@
                   "conversions/leads/introduction",
                   "conversions/leads/client-side",
                   {
-                    "group": "Auth providers",
+                    "group": "Third-party integrations",
                     "pages": [
+                      "conversions/leads/segment",
                       "conversions/leads/clerk",
                       "conversions/leads/better-auth",
                       "conversions/leads/next-auth",
@@ -72,8 +82,7 @@
                       "conversions/leads/auth0",
                       "conversions/leads/appwrite"
                     ]
-                  },
-                  "conversions/leads/segment"
+                  }
                 ]
               },
               {
@@ -81,16 +90,24 @@
                 "pages": [
                   "conversions/sales/introduction",
                   "conversions/sales/client-side",
-                  "conversions/sales/stripe",
-                  "conversions/sales/shopify",
-                  "conversions/sales/segment"
+                  {
+                    "group": "Third-party integrations",
+                    "pages": [
+                      "conversions/sales/segment",
+                      "conversions/sales/stripe",
+                      "conversions/sales/shopify"
+                    ]
+                  }
                 ]
               }
             ]
           },
           {
             "group": "Dub Partners",
-            "pages": ["partners/quickstart", "partners/embedded-referrals"]
+            "pages": [
+              "partners/quickstart",
+              "partners/embedded-referrals"
+            ]
           },
           {
             "group": "Integrations",
@@ -109,7 +126,10 @@
           },
           {
             "group": "Open source",
-            "pages": ["local-development", "self-hosting"]
+            "pages": [
+              "local-development",
+              "self-hosting"
+            ]
           }
         ]
       },
@@ -169,7 +189,10 @@
               },
               {
                 "group": "Embedded Dashboards",
-                "pages": ["sdks/embed/referrals", "sdks/embed/analytics"]
+                "pages": [
+                  "sdks/embed/referrals",
+                  "sdks/embed/analytics"
+                ]
               }
             ]
           },


### PR DESCRIPTION

<img width="381" height="734" alt="CleanShot 2025-09-22 at 11 29 38" src="https://github.com/user-attachments/assets/7547eef4-b5a4-4458-a058-e636b67a9a60" />


- Move third-party integrations into `third-party integrations` dropdown
- Adds `(<integration type>)` to each integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added sidebar titles to multiple integration guides (Appwrite, Auth0, Better Auth, Clerk, NextAuth.js, Supabase, Segment, Stripe, Shopify) to surface category tags.
  - Renamed “Auth providers” to “Third-party integrations” and added Segment to “Tracking lead events.”
  - Regrouped “Tracking sale events” under “Third-party integrations” with Segment, Stripe, and Shopify.
  - Reformatted navigation arrays for clearer structure across Getting Started, Conversions, Partners, Open Source, and SDKs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->