### PR TITLE
Updates swift target version docs

### DIFF
--- a/snippets/dub-client-mobile-install.mdx
+++ b/snippets/dub-client-mobile-install.mdx
@@ -8,7 +8,7 @@ import SaleAttributes from "/snippets/sale-attributes.mdx";
 **Build Tools:**
 
 - Xcode 16+
-- Swift 6+
+- Swift 4.0+
 
 **Platforms:**
 

--- a/snippets/steps/install-ios-sdk.mdx
+++ b/snippets/steps/install-ios-sdk.mdx
@@ -3,7 +3,7 @@ Before installing, ensure your environment meets these minimum requirements:
 
 **Build Tools:**
 - Xcode 16+
-- Swift 6+
+- Swift 4.0+
 
 **Platforms:**
 - iOS 16.0+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Build Tools requirement to Swift 4.0+ (from 6+) in mobile client installation and iOS SDK setup guides.
  * Clarified platform minimums remain unchanged (Xcode 16+, iOS 16.0+, macOS 13 Ventura+).
  * Improves compatibility for teams using older Swift toolchains; instructions unchanged otherwise.
  * No functional changes to the SDK or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->