### PR TITLE
Add comment for merging Clerk user metadata

### DIFF
--- a/conversions/leads/clerk.mdx
+++ b/conversions/leads/clerk.mdx
@@ -218,6 +218,20 @@ Here's a quick summary of the steps:
           dubClickId: dubId || "n/a",
         },
       });
+
+    /**
+     If have existing public metadata in your clerk user you will want to merge the existing metadata with the new metadata.
+     This is to avoid losing any existing metadata.
+
+      const usermetadata = await clerk.users.getUser(id);
+
+      await clerk.users.updateUser(id, {
+        publicMetadata: {
+          ...usermetadata.publicMetadata,
+          dubClickId: dubId || 'n/a',
+        });
+     */
+
       const res = NextResponse.json({ ok: true });
       // Delete the dub_id cookie
       res.cookies.set("dub_id", "", {


### PR DESCRIPTION
Added a comment explaining how to merge existing public metadata with new metadata in Clerk user updates.

I ran into this issue in development implementing the dub partners. The existing code overwrote my metadata I used to check for onboarding putting the user into an endless onboarding loop.

Onboarding flow was loosely based off Clerk's own documentation:
[https://clerk.com/docs/guides/development/add-onboarding-flow](https://clerk.com/docs/guides/development/add-onboarding-flow)

Hope this helps!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive code examples and guidance demonstrating best practices for preserving existing metadata when updating user information in Clerk integrations. Includes detailed examples for both server-side actions and API route handler approaches to help prevent data loss during metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->