### PR TITLE
Add `partner.application_submitted` webhook event

### DIFF
--- a/concepts/webhooks/event-types.mdx
+++ b/concepts/webhooks/event-types.mdx
@@ -31,6 +31,7 @@ These events are triggered in the context of your entire workspace:
 - [`link.deleted`](#link-deleted)
 - [`lead.created`](#lead-created)
 - [`sale.created`](#sale-created)
+- [`partner.application_submitted`](#partner-application-submitted)
 - [`partner.enrolled`](#partner-enrolled)
 - [`commission.created`](#commission-created)
 
@@ -493,6 +494,60 @@ Here's an example payload:
 ```
 
     </Accordion>
+
+### `partner.application_submitted`
+
+This event is triggered when a new application is submitted in the partner program. The event payload contains the following:
+
+- `partner`: Details about the partner who submitted the application.
+- `applicationFormData`: An array of application form fields with their labels and values submitted in the application.
+
+Here's an example payload:
+
+<Accordion title="Sample payload">
+```json partner.application_submitted
+{
+  "id": "evt_Xd0Ss0jMC0HZa9nxtMavb9eKn",
+  "event": "partner.application_submitted",
+  "createdAt": "2025-11-06T11:26:00.704Z",
+  "data": {
+    "id": "pga_1K9CEN4JWYACNHS4DR3PWNR2F",
+    "createdAt": "2025-11-06T11:25:59.264Z",
+    "partner": {
+      "id": "pn_1K9BZE1K285BSTX4W6MPKXJFZ",
+      "name": "Matthew Hayden",
+      "email": "matthew@example.com",
+      "companyName": null,
+      "image": null,
+      "description": "I'm a content creator who works with brands to grow their business.",
+      "country": "US",
+      "groupId": "grp_1K9BZE1K2RWYAWB2K1YN5TY7F",
+      "status": "pending",
+      "website": null,
+      "youtube": null,
+      "twitter": null,
+      "linkedin": null,
+      "instagram": null,
+      "tiktok": null
+    },
+    "applicationFormData": [
+      {
+        "label": "Website",
+        "value": "https://example.com/"
+      },
+      {
+        "label": "How do you plan to promote Acme?",
+        "value": "I'll promote Acme by sharing it on my social platforms and writing a blog post."
+      },
+      {
+        "label": "Any additional questions or comments?",
+        "value": null
+      }
+    ]
+  }
+}
+```
+</Accordion>
 
 ### `commission.created`
 

--- a/integrations.mdx
+++ b/integrations.mdx
@@ -147,10 +147,12 @@ Dub also supports webhooks for integrations. You can learn more about them in th
 
 Here's a list of the webhooks that Dub supports:
 
-- [`link.created`](/concepts/webhooks/event-types#link-created) – when a new link is created
-- [`link.updated`](/concepts/webhooks/event-types#link-updated) – when a link is updated
-- [`link.deleted`](/concepts/webhooks/event-types#link-deleted) – when a link is deleted
-- [`link.clicked`](/concepts/webhooks/event-types#link-clicked) – when a link is clicked
-- [`lead.created`](/concepts/webhooks/event-types#lead-created) – when a new lead is created
-- [`sale.created`](/concepts/webhooks/event-types#sale-created) – when a new sale is created
-- [`partner.enrolled`](/concepts/webhooks/event-types#partner-enrolled) – when a new partner is enrolled in your program
+- [`link.created`](/concepts/webhooks/event-types#link-created) – when a new link is created
+- [`link.updated`](/concepts/webhooks/event-types#link-updated) – when a link is updated
+- [`link.deleted`](/concepts/webhooks/event-types#link-deleted) – when a link is deleted
+- [`link.clicked`](/concepts/webhooks/event-types#link-clicked) – when a link is clicked
+- [`lead.created`](/concepts/webhooks/event-types#lead-created) – when a new lead is created
+- [`sale.created`](/concepts/webhooks/event-types#sale-created) – when a new sale is created
+- [`partner.application_submitted`](/concepts/webhooks/event-types#partner-application-submitted) – when a new application is submitted in the partner program
+- [`partner.enrolled`](/concepts/webhooks/event-types#partner-enrolled) – when a new partner is enrolled in your program
+- [`commission.created`](/concepts/webhooks/event-types#commission-created) – when a new commission is created


### PR DESCRIPTION
- Introduced the `partner.application_submitted` event to the webhook event types.
- Updated the integrations documentation to include the new event and its details.
- Enhanced the example payload for better clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded webhook events documentation to include two new event types: `partner.application_submitted` and `commission.created`. These events are now available for integration within your workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->