### PR TITLE
Update Tinybird CLI login command in docs

### DIFF
--- a/local-development.mdx
+++ b/local-development.mdx
@@ -167,7 +167,7 @@ In your newly-cloned Dub repo, navigate to the `packages/tinybird` directory.
 
     If you have `brew`, install `pipx` by running `brew install pipx`. If not, you can check [installation guide](https://pipx.pypa.io/stable/installation/) for other options. After that, install the Tinybird CLI with `pipx install tinybird-cli` (requires Python >= 3.8).
 
-    Run `tb login --interactive` and paste your `admin` Auth Token.
+    Run `tb auth --interactive` and paste your `admin` Auth Token.
 
   </Step>
 


### PR DESCRIPTION
Replaces the deprecated 'tb login --interactive' command with 'tb auth --interactive' in the local development documentation to reflect the latest Tinybird CLI usage.

<img width="1468" height="660" alt="CleanShot 2025-12-15 at 09 02 04@2x" src="https://github.com/user-attachments/assets/9cb5d9df-eb83-42be-997d-31f06fd6efa6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Tinybird authentication command syntax in local development documentation to reflect current CLI usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->