### PR TITLE
docs(stripe): Fix anchor link for integration options

### DIFF
--- a/docs/integrations/stripe.mdx
+++ b/docs/integrations/stripe.mdx
@@ -119,8 +119,8 @@ Once the integration is installed, Dub will automatically listen to the followin
 Depending on your setup, there are a few ways you can track sales with the Dub Stripe integration.
 
 - [Option 1: Using Stripe Payment Links](#option-1-using-stripe-payment-links)
-- [Option 2: Using Stripe Checkout (recommended)](#option-2%3A-using-stripe-checkout-recommended)
-- [Option 3: Using Stripe Customers](#option-3%3A-using-stripe-customers)
+- [Option 2: Using Stripe Checkout (recommended)](#option-2-using-stripe-checkout-recommended)
+- [Option 3: Using Stripe Customers](#option-3-using-stripe-customers)
 
 ### Option 1: Using Stripe Payment Links
 


### PR DESCRIPTION
This pull request makes a minor correction to the Stripe integration documentation. It updates the anchor links for "Option 2" and "Option 3" in the sales tracking section to use the correct URL encoding, ensuring that the links work as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Stripe integration documentation with improved content organization in the "Tracking sales" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->