### PR TITLE
Reason clarification

### DIFF
--- a/help/article/fraud-detection.mdx
+++ b/help/article/fraud-detection.mdx
@@ -28,12 +28,11 @@ Here are the event types you might see flagged and detected in your program.
 
 | Event  | Description  |
 | --- | ---- |
-| Cross-program ban  | This partner has been banned from one or more other Dub programs, indicating a potential high-risk history. To protect security and privacy, specific details such as links, evidence, or notes are not shared across programs. |
-| Duplicate payout method  | This partner is using a payout method that is already linked to another partner account, which may indicate account duplication or fraudulent behavior. |
+| Duplicate payout method  | This payout method is already linked to another partner. May indicate duplicate accounts or fraud, and is flagged to prevent abuse of restrictions, caps, or bonuses. |
 | Matching customer email  | Partner's email matches a customer's email and could be a self-referral. |
-| Suspicious customer email domain | Customer's email uses a disposable or temporary domain, which could be a fraud attempt.                                                                                                                                         |
-| Banned referral source           | A conversion, event, or click was made on a banned referral domain.                                                                                                                                                             |
-| Paid traffic                     | A conversion, event, or click was made from paid advertising traffic.                                                                                                                                                           |
+| Suspicious customer email domain | Customer's email uses a disposable or temporary domain, which could be a fraud attempt. |
+| Banned referral source | A conversion, event, or click was made on a banned referral domain. |
+| Paid traffic | A conversion, event, or click was made from paid advertising traffic. |
 
 ## Reviewing fraud events
 


### PR DESCRIPTION
Removed the cross-program ban for now, and updated the duplicate payout method reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced fraud detection event descriptions in help documentation for improved clarity and accuracy.
  * Refined explanations for multiple fraud event types including payout method validation, email domain verification, referral source tracking, and paid advertising monitoring to better illustrate detection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->