### PR TITLE
Performance logic updated

### DIFF
--- a/help/article/program-bounties.mdx
+++ b/help/article/program-bounties.mdx
@@ -85,7 +85,7 @@ When setting the logic for a performance bounty, you can choose from several opt
 
 **Scope** determines how performance is tracked over a specific period.
 
-- **New** - Tracks only performance generated after the bounty is created. For example, if you set a bounty that rewards partners after 10 leads, each partner must generate 10 new leads after the bounty goes live, regardless of how many leads they had before.
+- **New** - Tracks only performance generated after the bounty starts. For example, if you set a bounty that rewards partners after 10 leads, each partner must generate 10 new leads after the bounty goes live, regardless of how many leads they had before. For revenue-based bounties, only revenue from customers whose first sale happens after the bounty starts is counted.
 - **Lifetime** - Counts performance across the partner’s entire lifetime. For example, if you set a bounty that rewards after 10 leads, any partner who already has at least 10 leads will immediately qualify for the reward.
 
 **Activity** determines which metric is tracked for the bounty. Revenue and commissions require a dollar amount to be set.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance bounties scope description to clarify that performance is tracked only after the bounty starts and that only revenue from new customers (whose first sale occurs after the bounty start) is counted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->