### PR TITLE
Importing partners update

### DIFF
--- a/help/article/importing-partners.mdx
+++ b/help/article/importing-partners.mdx
@@ -33,8 +33,9 @@ From the partner table, click the `⋮` menu to import partners from supported p
 Dub currently supports importing from:
 
 - [Rewardful](/help/article/migrating-from-rewardful)
-- [Tolt](/help/article/migrating-from-tolt)
 - [PartnerStack](/help/article/migrating-from-partnerstack)
 - [FirstPromoter](/help/article/migrating-from-firstpromoter)
+- [Tapfiliate](/help/article/migrating-from-tapfiliate)
+- [Tolt](/help/article/migrating-from-tolt)
 
 If you’d like to import from other platforms, [let us know](https://dub.co/contact/support).


### PR DESCRIPTION
- was missing tapfiliate
- matching the order in the migration guides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the importing-partners help article to reflect additional supported import sources.
  * Reordered the supported platforms list for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->