### PR TITLE
On hold addition

### DIFF
--- a/help/article/commissions-payouts.mdx
+++ b/help/article/commissions-payouts.mdx
@@ -30,6 +30,7 @@ Payouts on Dub go through the following statuses:
 
 - `Pending`: When you start earning commissions from a program, they'll be accrued under a payout entry. If the program has a [minimum payout amount](#what-does-minimum-payout-amount-mean) set, your payout amount will need to reach the threshold to become eligible for payment.
 - `Processing`: When a program initiates a payout to you, the payout will be updated to a "processing" state until the payment settles on Dub. This process can take up to 5 business days.
+- `On Hold`: When a commission is temporarily paused due to pending risk events. On-hold commissions cannot be paid out until the program reviews and resolves the issue. If you believe this is incorrect, reach out to the program’s support team.
 - `Processed`: Once the program's payout has settled on Dub, the payout will be updated to a "processed" state. If the payout amount is above your [minimum withdrawal balance](/help/article/receiving-payouts#what-is-the-minimum-withdrawal-amount-and-how-does-it-work), the funds will be automatically paid out to your connected bank account.
 - `Sent`: When your payout is on its way to your connected bank account, it will be updated to a "sent" state. Depending on your bank location, this can take anywhere from 1 to 14 business days (you will see the estimated arrival date in the notification email from Dub).
 - `Completed`: When the payout is completed and the funds are deposited into your bank account.

--- a/help/article/partner-commissions.mdx
+++ b/help/article/partner-commissions.mdx
@@ -53,6 +53,7 @@ When a commission is recorded on Dub, it goes through the following statuses:
 - `Pending`: This is the initial status for a commission. Depending on your program's [holding period](/help/article/partner-payouts#payout-holding-period), commissions can stay in "pending" status anywhere from less than a day to 90 days.
 - `Processed`: When a commission has been added to a payout (after any applicable [holding period](/help/article/partner-payouts#payout-holding-period)), its status will change from "pending" to "processed".
 - `Paid`: When the payout containing the commission has been paid, the commission will be updated to "paid" status.
+- `On Hold`: When a commission is paused due to a pending risk event. On-hold commissions cannot be added to a payout until the risk event is resolved.
 
 If needed, you can also update the status for a given commission accordingly:
 
@@ -379,4 +380,3 @@ After receiving the email, click **Download export** to download your commission
     alt="Commission export email"
   />
 </Frame>
-


### PR DESCRIPTION
Updating the status details for programs and partners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an **On Hold** commission status to help articles.
  * Clarified that commissions in this state are temporarily paused and can’t be included in payouts until the issue is resolved.
  * Updated guidance to contact support if a commission appears to be on hold incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->